### PR TITLE
Add initial support for Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Mandatory Features
  - Provide a path for a directory to generate html files for each text file within folder
  - Adds HTML markup tags such as `<p>...</p>` to text
  - Outputs files to `./til` folder by default
+ - Handle markdown files
 
 Optional Features
 - Parses title from text file to enhance HTML with `<h1>...</h1>` markup tags

--- a/examples/markdown_Sample.md
+++ b/examples/markdown_Sample.md
@@ -1,1 +1,4 @@
+**Markdown** Sample File
+
+
 This is an example of markdown with **bold** text.

--- a/examples/markdown_Sample.md
+++ b/examples/markdown_Sample.md
@@ -1,0 +1,1 @@
+This is an example of markdown with **bold** text.

--- a/src/markdownToHTML.js
+++ b/src/markdownToHTML.js
@@ -1,0 +1,19 @@
+// Parse Markdown tags and convert into html tag
+const markdownToHTML = (text) => {
+    let html = text;
+
+    // Convert bold markdown to html <b> tags
+    const boldPattern1 = /\*\*([^*]+)\*\*/g;
+    html = html.replace(boldPattern1, (match, boldText) => {
+      return `<b>${boldText}</b>`;
+    });
+  
+    const boldPattern2 = /\_\_([^*]+)\_\_/g;
+    html = html.replace(boldPattern2, (match, boldText) => {
+      return `<b>${boldText}</b>`;
+    });
+
+    return html;
+}
+
+module.exports = markdownToHTML;

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const { version } = require("../package.json");
 const { start } = require( "repl" );
+const markdownToHTML = require("./markdownToHTML.js");
 
 /* Help message that shows how to use tool and the options that are available */
 const helpManual = () => {
@@ -70,23 +71,30 @@ const generateHTML = (fileData, filePath, outputFolder) => {
     </body>
     </html>`;
 
-    // Write text to HTML file -- Need to update for custom output path
+    // Write input to HTML file -- Need to update for custom output path
     try {
-      fs.writeFileSync(`${outputFolder}/${path.basename(filePath[i], ".txt")}.html`, html);
+      const fileType = filePath[i].split(".")[1];
+      
+      fs.writeFileSync(`${outputFolder}/${path.basename(filePath[i], `.${fileType}`)}.html`, html);
       // need to update for custom output path
-      console.log(`File successfully written at: ${outputFolder}/${path.basename(filePath[i], ".txt")}.html`);
+      console.log(`File successfully written at: ${outputFolder}/${path.basename(filePath[i], `.${fileType}`)}.html`);
     } catch (err) {
       console.error(err);
     }
   }
 };
 
-const addHTMLMarkup = (lines) => {
+const addHTMLMarkup = (lines, fileType) => {
   let body = lines;
   let markupTitle = "";
   let paragraphs = [""];
   let startIndex = 0;
   let pIndex = 0;
+
+  // Parse markdown tags
+  if (fileType === "md") {
+    body = body.map(line => markdownToHTML(line));
+  }
 
   // Check if there is a title in text file
   if (
@@ -141,7 +149,8 @@ const readFileFromPath = (filePath, outputFolder) => {
       console.error(`Error while processing text file\nError: ${err}`);
       return;
     }
-    markupData.push(addHTMLMarkup(data.split("\r\n")));
+    const fileType = filePath[a].split(".").pop();
+    markupData.push(addHTMLMarkup(data.split("\r\n"), fileType));
   }
 
   try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,11 +73,9 @@ const generateHTML = (fileData, filePath, outputFolder) => {
 
     // Write input to HTML file -- Need to update for custom output path
     try {
-      const fileType = filePath[i].split(".")[1];
-      
-      fs.writeFileSync(`${outputFolder}/${path.basename(filePath[i], `.${fileType}`)}.html`, html);
+      fs.writeFileSync(`${outputFolder}/${path.basename(filePath[i], path.extname(filePath[i]))}.html`, html);
       // need to update for custom output path
-      console.log(`File successfully written at: ${outputFolder}/${path.basename(filePath[i], `.${fileType}`)}.html`);
+      console.log(`File successfully written at: ${outputFolder}/${path.basename(filePath[i], path.extname(filePath[i]))}.html`);
     } catch (err) {
       console.error(err);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -161,9 +161,11 @@ const determinePath = (inputPath, outputFolder = "./til") => {
   let directoryFilePath = [];
   try {
     // Check if path is a text file or directory and try to read it
+    const fileTypes = [".txt", ".md"];
+
     if (
       fs.statSync(inputPath[0]).isFile() &&
-      path.extname(inputPath[0]) === ".txt"
+      fileTypes.includes(path.extname(inputPath[0]))
     ) {
       console.log("File path received. \n");
       readFileFromPath(inputPath, outputFolder);
@@ -176,9 +178,9 @@ const determinePath = (inputPath, outputFolder = "./til") => {
           console.error(`Unable to read directory.\nError: ${err}`);
           return;
         } else {
-          // Get all file paths from directory that end with .txt
+          // Get all file paths from directory that end with .txt or .md
           for (let i = 0; i < files.length; i++) {
-            if (path.extname(files[i]) === ".txt") {
+            if (fileTypes.includes(path.extname(files[i]))) {
               directoryFilePath.push(`${inputPath[0]}/${files[i]}`);
             }
           }


### PR DESCRIPTION
Fixes #8 
- Modified `determinePath` and `generateHTML` functions to handle input files with extension `.md`
- Added `markdownToHTML` module that parses markdown bold tags as HTML `<b>` tags
- Added note to `README.md`